### PR TITLE
Fee pot2

### DIFF
--- a/accounts/abi/bind/backends/simulated.go
+++ b/accounts/abi/bind/backends/simulated.go
@@ -648,7 +648,7 @@ func (b *SimulatedBackend) callContract(ctx context.Context, call ethereum.CallM
 	vmEnv := vm.NewEVM(evmContext, txContext, stateDB, b.config, vm.Config{NoBaseFee: true})
 	gasPool := new(core.GasPool).AddGas(math.MaxUint64)
 
-	return core.NewStateTransition(vmEnv, msg, gasPool).TransitionDb()
+	return core.NewStateTransition(vmEnv, msg, gasPool).TransitionDb(b.blockchain.Engine())
 }
 
 // SendTransaction updates the pending block to include the given transaction.

--- a/consensus/cliquepcr/cliquepocr.go
+++ b/consensus/cliquepcr/cliquepocr.go
@@ -200,6 +200,10 @@ func (c *CliquePoCR) Close() error {
 func (c *CliquePoCR) Authorize(signer common.Address, signFn clique.SignerFn) {
 	c.EngineInstance.Authorize(signer, signFn)
 }
+func (c *CliquePoCR) ManageFees(aVMStateDB vm.StateDB, feeReceiver common.Address, feeAmount *big.Int) error {
+	log.Info("Managing fees in cliquepcr", "address = ", feeReceiver, "fee =", feeAmount)
+	return nil
+}
 
 // AccumulateRewards credits the coinbase of the given block with the mining
 // reward. The total reward consists of the static block reward and rewards for
@@ -404,11 +408,6 @@ func NewCarbonFootPrintContract(nodeAddress common.Address, config *params.Chain
 	cfg := runtime.Config{ChainConfig: config, Origin: nodeAddress, GasLimit: 1000000, State: stateCopy, BlockNumber: block}
 	contract.RuntimeConfig = &cfg
 	return contract
-}
-
-func ManageFees(aVMStateDB vm.StateDB, feeReceiver common.Address, feeAmount *big.Int) error {
-	log.Info("Managing fees in cliquepcr", "address = ", feeReceiver, "fee =", feeAmount)
-	return nil
 }
 
 // func (contract *CarbonFootprintContract) getBalance() (*big.Int, error) {

--- a/consensus/cliquepcr/cliquepocr.go
+++ b/consensus/cliquepcr/cliquepocr.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ethereum/go-ethereum/consensus/clique"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/core/vm/runtime"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -403,6 +404,11 @@ func NewCarbonFootPrintContract(nodeAddress common.Address, config *params.Chain
 	cfg := runtime.Config{ChainConfig: config, Origin: nodeAddress, GasLimit: 1000000, State: stateCopy, BlockNumber: block}
 	contract.RuntimeConfig = &cfg
 	return contract
+}
+
+func ManageFees(aVMStateDB vm.StateDB, feeReceiver common.Address, feeAmount *big.Int) error {
+	log.Info("Managing fees in cliquepcr", "address = ", feeReceiver, "fee =", feeAmount)
+	return nil
 }
 
 // func (contract *CarbonFootprintContract) getBalance() (*big.Int, error) {

--- a/consensus/cliquepcr/cliquepocr.go
+++ b/consensus/cliquepcr/cliquepocr.go
@@ -200,6 +200,7 @@ func (c *CliquePoCR) Close() error {
 func (c *CliquePoCR) Authorize(signer common.Address, signFn clique.SignerFn) {
 	c.EngineInstance.Authorize(signer, signFn)
 }
+
 func (c *CliquePoCR) ManageFees(aVMStateDB vm.StateDB, feeReceiver common.Address, feeAmount *big.Int) error {
 	log.Info("Managing fees in cliquepcr", "address = ", feeReceiver, "fee =", feeAmount)
 	return nil

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -132,3 +132,9 @@ type PoW interface {
 	// Hashrate returns the current mining hashrate of a PoW consensus engine.
 	Hashrate() float64
 }
+
+// FeeManagementEngine is a consensus engine that ovverides default fee management logic with custom one.
+type FeeManagementEngine interface {
+	Engine
+	ManageFees(chain ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction) error
+}

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -134,8 +134,9 @@ type PoW interface {
 	Hashrate() float64
 }
 
-// FeeManagementEngine is a consensus engine that ovverides default fee management logic with custom one.
-type FeeManagementEngine interface {
+type ManageFees interface {
 	Engine
+
+	// Interface to manage fees/ Returns false if the engine does not want to override fees
 	ManageFees(vm.StateDB, common.Address, *big.Int) error
 }

--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rpc"
 )
@@ -136,5 +137,5 @@ type PoW interface {
 // FeeManagementEngine is a consensus engine that ovverides default fee management logic with custom one.
 type FeeManagementEngine interface {
 	Engine
-	ManageFees(chain ChainHeaderReader, header *types.Header, state *state.StateDB, txs []*types.Transaction) error
+	ManageFees(vm.StateDB, common.Address, *big.Int) error
 }

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1668,7 +1668,8 @@ func (bc *BlockChain) insertChain(chain types.Blocks, verifySeals, setHead bool)
 
 		// Process block using the parent state as reference point
 		substart := time.Now()
-		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig)
+		usedEngine := bc.engine
+		receipts, logs, usedGas, err := bc.processor.Process(block, statedb, bc.vmConfig, usedEngine)
 		if err != nil {
 			bc.reportBlock(block, receipts, err)
 			atomic.StoreUint32(&followupInterrupt, 1)

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -103,7 +103,7 @@ func (b *BlockGen) AddTxWithChain(bc *BlockChain, tx *types.Transaction) {
 		b.SetCoinbase(common.Address{})
 	}
 	b.statedb.Prepare(tx.Hash(), len(b.txs))
-	receipt, err := ApplyTransaction(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{})
+	receipt, err := ApplyTransactionWithEngine(b.config, bc, &b.header.Coinbase, b.gasPool, b.statedb, b.header, tx, &b.header.GasUsed, vm.Config{}, b.engine)
 	if err != nil {
 		panic(err)
 	}

--- a/core/state_prefetcher.go
+++ b/core/state_prefetcher.go
@@ -68,7 +68,7 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 			return // Also invalid block, bail out
 		}
 		statedb.Prepare(tx.Hash(), i)
-		if err := precacheTransaction(msg, p.config, gaspool, statedb, header, evm); err != nil {
+		if err := p.precacheTransaction(msg, p.config, gaspool, statedb, header, evm); err != nil {
 			return // Ugh, something went horribly wrong, bail out
 		}
 		// If we're pre-byzantium, pre-load trie nodes for the intermediate root
@@ -85,10 +85,10 @@ func (p *statePrefetcher) Prefetch(block *types.Block, statedb *state.StateDB, c
 // precacheTransaction attempts to apply a transaction to the given state database
 // and uses the input parameters for its environment. The goal is not to execute
 // the transaction successfully, rather to warm up touched data slots.
-func precacheTransaction(msg types.Message, config *params.ChainConfig, gaspool *GasPool, statedb *state.StateDB, header *types.Header, evm *vm.EVM) error {
+func (p *statePrefetcher) precacheTransaction(msg types.Message, config *params.ChainConfig, gaspool *GasPool, statedb *state.StateDB, header *types.Header, evm *vm.EVM) error {
 	// Update the evm with the new transaction context.
 	evm.Reset(NewEVMTxContext(msg), statedb)
 	// Add addresses to access list if applicable
-	_, err := ApplyMessage(evm, msg, gaspool)
+	_, err := ApplyMessage(evm, msg, gaspool, p.engine)
 	return err
 }

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -354,18 +353,13 @@ func (st *StateTransition) TransitionDb(engine consensus.Engine) (*ExecutionResu
 	} else {
 		fee := new(big.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTip)
-		var i interface{} = engine
-		if _, ok := i.(consensus.FeeManagementEngine); ok {
-			err1 := engine.(consensus.FeeManagementEngine).ManageFees(st.state, st.evm.Context.Coinbase, fee)
+		if managefee, ok := engine.(consensus.ManageFees); ok {
+			err1 := managefee.ManageFees(st.state, st.evm.Context.Coinbase, fee)
 			if err1 != nil {
 				return nil, err1
 			}
-		} else {
-			log.Info("ManageFees not implemented")
-			st.state.AddBalance(st.evm.Context.Coinbase, fee)
 		}
 	}
-
 	return &ExecutionResult{
 		UsedGas:    st.gasUsed(),
 		Err:        vmerr,

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -353,11 +354,16 @@ func (st *StateTransition) TransitionDb(engine consensus.Engine) (*ExecutionResu
 	} else {
 		fee := new(big.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTip)
+		log.Info("fee management: ", "fee", fee)
 		if managefee, ok := engine.(consensus.ManageFees); ok {
+			log.Info("fee management ok: ", "fee", fee)
 			err1 := managefee.ManageFees(st.state, st.evm.Context.Coinbase, fee)
 			if err1 != nil {
 				return nil, err1
 			}
+		} else {
+			log.Info("fee management not ok: ", "fee", fee)
+			st.state.AddBalance(st.evm.Context.Coinbase, fee)
 		}
 	}
 	return &ExecutionResult{

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	cmath "github.com/ethereum/go-ethereum/common/math"
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -177,8 +178,8 @@ func NewStateTransition(evm *vm.EVM, msg Message, gp *GasPool) *StateTransition 
 // the gas used (which includes gas refunds) and an error if it failed. An error always
 // indicates a core error meaning that the message would always fail for that particular
 // state and would never be accepted within a block.
-func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool) (*ExecutionResult, error) {
-	return NewStateTransition(evm, msg, gp).TransitionDb()
+func ApplyMessage(evm *vm.EVM, msg Message, gp *GasPool, engine consensus.Engine) (*ExecutionResult, error) {
+	return NewStateTransition(evm, msg, gp).TransitionDb(engine)
 }
 
 // to returns the recipient of the message.
@@ -272,7 +273,7 @@ func (st *StateTransition) preCheck() error {
 //
 // However if any consensus issue encountered, return the error directly with
 // nil evm execution result.
-func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
+func (st *StateTransition) TransitionDb(engine consensus.Engine) (*ExecutionResult, error) {
 	// First check this message satisfies all consensus rules before
 	// applying the message. The rules include these clauses
 	//
@@ -352,6 +353,7 @@ func (st *StateTransition) TransitionDb() (*ExecutionResult, error) {
 	} else {
 		fee := new(big.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTip)
+
 		st.state.AddBalance(st.evm.Context.Coinbase, fee)
 	}
 

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"math"
 	"math/big"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/common"
 	cmath "github.com/ethereum/go-ethereum/common/math"
@@ -354,7 +355,7 @@ func (st *StateTransition) TransitionDb(engine consensus.Engine) (*ExecutionResu
 	} else {
 		fee := new(big.Int).SetUint64(st.gasUsed())
 		fee.Mul(fee, effectiveTip)
-		log.Info("fee management: ", "fee", fee)
+		log.Info("fee management: ", "fee", fee, "type", reflect.TypeOf(engine))
 		if managefee, ok := engine.(consensus.ManageFees); ok {
 			log.Info("fee management ok: ", "fee", fee)
 			err1 := managefee.ManageFees(st.state, st.evm.Context.Coinbase, fee)

--- a/core/state_transition.go
+++ b/core/state_transition.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/params"
 )
 
@@ -360,6 +361,7 @@ func (st *StateTransition) TransitionDb(engine consensus.Engine) (*ExecutionResu
 				return nil, err1
 			}
 		} else {
+			log.Info("ManageFees not implemented")
 			st.state.AddBalance(st.evm.Context.Coinbase, fee)
 		}
 	}

--- a/core/types.go
+++ b/core/types.go
@@ -17,6 +17,7 @@
 package core
 
 import (
+	"github.com/ethereum/go-ethereum/consensus"
 	"github.com/ethereum/go-ethereum/core/state"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/core/vm"
@@ -47,5 +48,5 @@ type Processor interface {
 	// Process processes the state changes according to the Ethereum rules by running
 	// the transaction messages using the statedb and applying any rewards to both
 	// the processor (coinbase) and any included uncles.
-	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config) (types.Receipts, []*types.Log, uint64, error)
+	Process(block *types.Block, statedb *state.StateDB, cfg vm.Config, engine consensus.Engine) (types.Receipts, []*types.Log, uint64, error)
 }

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -348,7 +348,7 @@ func (b *EthAPIBackend) ServiceFilter(ctx context.Context, session *bloombits.Ma
 }
 
 func (b *EthAPIBackend) Engine() consensus.Engine {
-	return b.eth.engine
+	return b.eth.Engine()
 }
 
 func (b *EthAPIBackend) CurrentHeader() *types.Header {

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -131,7 +131,8 @@ func (eth *Ethereum) StateAtBlock(block *types.Block, reexec uint64, base *state
 		if current = eth.blockchain.GetBlockByNumber(next); current == nil {
 			return nil, fmt.Errorf("block #%d not found", next)
 		}
-		_, _, _, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{})
+
+		_, _, _, err := eth.blockchain.Processor().Process(current, statedb, vm.Config{}, eth.Engine())
 		if err != nil {
 			return nil, fmt.Errorf("processing block %d failed: %v", current.NumberU64(), err)
 		}
@@ -191,7 +192,7 @@ func (eth *Ethereum) stateAtTransaction(block *types.Block, txIndex int, reexec 
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, eth.blockchain.Config(), vm.Config{})
 		statedb.Prepare(tx.Hash(), idx)
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()), eth.EthereumEngine); err != nil {
 			return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state

--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -533,7 +533,8 @@ func (api *API) IntermediateRoots(ctx context.Context, hash common.Hash, config 
 			vmenv     = vm.NewEVM(vmctx, txContext, statedb, chainConfig, vm.Config{})
 		)
 		statedb.Prepare(tx.Hash(), i)
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
+
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), api.backend.Engine()); err != nil {
 			log.Warn("Tracing intermediate roots did not complete", "txindex", i, "txhash", tx.Hash(), "err", err)
 			// We intentionally don't return the error here: if we do, then the RPC server will not
 			// return the roots. Most likely, the caller already knows that a certain transaction fails to
@@ -627,7 +628,7 @@ func (api *API) traceBlock(ctx context.Context, block *types.Block, config *Trac
 		msg, _ := tx.AsMessage(signer, block.BaseFee())
 		statedb.Prepare(tx.Hash(), i)
 		vmenv := vm.NewEVM(blockCtx, core.NewEVMTxContext(msg), statedb, api.backend.ChainConfig(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas())); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), api.backend.Engine()); err != nil {
 			failed = err
 			break
 		}
@@ -740,7 +741,7 @@ func (api *API) standardTraceBlockToFile(ctx context.Context, block *types.Block
 		// Execute the transaction and flush any traces to disk
 		vmenv := vm.NewEVM(vmctx, txContext, statedb, chainConfig, vmConf)
 		statedb.Prepare(tx.Hash(), i)
-		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
+		_, err = core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), api.backend.Engine())
 		if writer != nil {
 			writer.Flush()
 		}
@@ -907,7 +908,7 @@ func (api *API) traceTx(ctx context.Context, message core.Message, txctx *Contex
 	vmenv := vm.NewEVM(vmctx, txContext, statedb, api.backend.ChainConfig(), vm.Config{Debug: true, Tracer: tracer, NoBaseFee: true})
 	// Call Prepare to clear out the statedb access list
 	statedb.Prepare(txctx.TxHash, txctx.TxIndex)
-	if _, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas())); err != nil {
+	if _, err = core.ApplyMessage(vmenv, message, new(core.GasPool).AddGas(message.Gas()), api.backend.Engine()); err != nil {
 		return nil, fmt.Errorf("tracing failed: %w", err)
 	}
 	return tracer.GetResult()

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -98,7 +98,7 @@ func BenchmarkTransactionTrace(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		snap := statedb.Snapshot()
 		st := core.NewStateTransition(evm, msg, new(core.GasPool).AddGas(tx.Gas()))
-		_, err = st.TransitionDb()
+		_, err = st.TransitionDb(nil)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -961,7 +961,7 @@ func DoCall(ctx context.Context, b Backend, args TransactionArgs, blockNrOrHash 
 
 	// Execute the message.
 	gp := new(core.GasPool).AddGas(math.MaxUint64)
-	result, err := core.ApplyMessage(evm, msg, gp)
+	result, err := core.ApplyMessage(evm, msg, gp, b.Engine())
 	if err := vmError(); err != nil {
 		return nil, err
 	}
@@ -1438,7 +1438,7 @@ func AccessList(ctx context.Context, b Backend, blockNrOrHash rpc.BlockNumberOrH
 		if err != nil {
 			return nil, 0, nil, err
 		}
-		res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()))
+		res, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(msg.Gas()), b.Engine())
 		if err != nil {
 			return nil, 0, nil, fmt.Errorf("failed to apply transaction: %v err: %v", args.toTransaction().Hash(), err)
 		}

--- a/les/state_accessor.go
+++ b/les/state_accessor.go
@@ -64,7 +64,7 @@ func (leth *LightEthereum) stateAtTransaction(ctx context.Context, block *types.
 		}
 		// Not yet the searched for transaction, execute on top of the current state
 		vmenv := vm.NewEVM(context, txContext, statedb, leth.blockchain.Config(), vm.Config{})
-		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas())); err != nil {
+		if _, err := core.ApplyMessage(vmenv, msg, new(core.GasPool).AddGas(tx.Gas()), leth.Engine()); err != nil {
 			return nil, vm.BlockContext{}, nil, fmt.Errorf("transaction %#x failed: %v", tx.Hash(), err)
 		}
 		// Ensure any modifications are committed to the state

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -825,7 +825,7 @@ func (w *worker) updateSnapshot(env *environment) {
 func (w *worker) commitTransaction(env *environment, tx *types.Transaction) ([]*types.Log, error) {
 	snap := env.state.Snapshot()
 
-	receipt, err := core.ApplyTransaction(w.chainConfig, w.chain, &env.coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, *w.chain.GetVMConfig())
+	receipt, err := core.ApplyTransactionWithEngine(w.chainConfig, w.chain, &env.coinbase, env.gasPool, env.state, env.header, tx, &env.header.GasUsed, *w.chain.GetVMConfig(), w.engine)
 	if err != nil {
 		env.state.RevertToSnapshot(snap)
 		return nil, err


### PR DESCRIPTION
@guenoledc @guenole-dc 
Hi guénolé, this is the Feepot interface implementation where you reach the consensus Engine  anytime you have a fee to be paid
(you reach https://github.com/ethereum-pocr/go-ethereum/blob/82bae6100a58c9714b44b75c849e952d042a25ab/consensus/cliquepcr/cliquepocr.go#L205 and it has been tested).

This is not complete yet, you will have to do the formula BaseRewardWithoutInflation*fee and get the remaining to be burned in the cliquepcrt ManageFee method, but the difficult plumbing is done.

Only the Engine implementing the ManagingFees interface defined in consensus.go will be called, others (ethash or basic clique) are not impacted. Also I had to modify the beaconchain, the based proxy.

The remaining work is to be bale to retrieve the contract without the header from the ManageFees interface knowing we only only have vm.StateDB in the context of fee management. We could use aVMStateDB.SetState and delay the fees payment to later FinalizeAndAssemble. This would work and I am wondering if deferring the fee is introducing any security issue though, not really sure at that stage. 
